### PR TITLE
controllers: addition of ``$sce`` service

### DIFF
--- a/src/cds/record/module.js
+++ b/src/cds/record/module.js
@@ -30,7 +30,7 @@
     * @description
     *    CDS record controller.
     */
-  function cdsRecordController($scope) {
+  function cdsRecordController($scope, $sce) {
 
     // Parameters
 
@@ -49,6 +49,17 @@
     ////////////
 
     // Functions
+
+    /**
+      * Trust iframe url
+      * @memberof cdsRecordController
+      * @function cdsRecordIframe
+      * @param {String} url - The url.
+      */
+    function cdsRecordIframe(url) {
+      // Return the trusted url
+      return $sce.trustAsResourceUrl(url);
+    }
 
     /**
       * When the module initialized
@@ -113,6 +124,13 @@
 
     ////////////
 
+    // Assignements
+
+    // Iframe src
+    vm.iframeSrc = cdsRecordIframe;
+
+    ////////////
+
     // Listeners
 
     // When the module initialized
@@ -129,7 +147,7 @@
     $scope.$on('cds.record.loading.stop', cdsRecordLoadingStop);
   }
 
-  cdsRecordController.$inject = ['$scope'];
+  cdsRecordController.$inject = ['$scope', '$sce'];
 
   ////////////
 

--- a/test/unit/cds/record/controllers/controllersSpec.js
+++ b/test/unit/cds/record/controllers/controllersSpec.js
@@ -95,6 +95,10 @@ describe('Unit: testing controllers', function() {
 
     // Expect loading to be ``false``
     expect(ctrl.cdsRecordLoading).to.be.equal(false);
+
+    // Expect the url to be ``object``
+    var url = ctrl.iframeSrc('suicide squad://Harlay Quinn');
+    expect(typeof url).to.be.equal('object');
   });
 
 });


### PR DESCRIPTION
- Adds the `$sce` service so we can now include iframes, by default
  angular prevent iframes to be loaded. In order to load them we have to
  trust their url through the `$sce` service.

Signed-off-by: Harris Tzovanakis me@drjova.com
